### PR TITLE
Allow variadic arguments for actions

### DIFF
--- a/app/schema/actions/README.md
+++ b/app/schema/actions/README.md
@@ -116,6 +116,9 @@ An `action` **MUST** declare all arguments it accepts. Each argument, will have 
     "default": {
         "desc": "The default value if not provided by the user (**not** available for types `map` or `object`)"
     },
+    "variadic": {
+        "desc": "Whether the action accepts unspecified arguments. The default value for this is `false`"
+    },
     "pattern": {
         "desc": "[Read more](#patterns) (for `type: string` only)"
     },


### PR DESCRIPTION
Fixes https://github.com/microservices/microservice.guide/issues/119

Use case 1: string templates / formatting

```coffee
format render :template name:user.name
```

See also: https://github.com/storyscript/storyscript/issues/1044

Use case 2: logging

```coffee
log info :user :location
```

`variadic` true implies that the runtime / compiler will not throw an error for unspecified arguments.

More details on this topic in general: https://en.wikipedia.org/wiki/Variadic_function